### PR TITLE
Remove debugger statement

### DIFF
--- a/scripts/module.js
+++ b/scripts/module.js
@@ -20,7 +20,6 @@ Hooks.on("renderRollTableConfig", (config, html, css) => {
 
 
 function updateMode(wrapped, ...args) {
-    debugger
     if(this.getFlag("hidden-tables", "hidden")) args[0].rollMode = "gmroll";
     return wrapped( ...args)
 }


### PR DESCRIPTION
Debugger statements can be annoying for users using the console to debug macros, especially if the macro draws multiple RollTables.